### PR TITLE
Fix ChoiceChip toggle behavior

### DIFF
--- a/lib/feature/files_list/widget/files_list_widget.dart
+++ b/lib/feature/files_list/widget/files_list_widget.dart
@@ -45,14 +45,18 @@ class _FilesListWidgetState extends State<FilesListWidget> {
                 selected: selectedType == null,
                 onSelected: (_) => setState(() => selectedType = null),
               ),
-              ...fileTypes.map((type) => Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 4.0),
-                child: ChoiceChip(
-                  label: Text(type.toUpperCase()),
-                  selected: selectedType == type,
-                  onSelected: (_) => setState(() => selectedType = type),
+              ...fileTypes.map(
+                (type) => Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 4.0),
+                  child: ChoiceChip(
+                    label: Text(type.toUpperCase()),
+                    selected: selectedType == type,
+                    onSelected: (selected) => setState(
+                      () => selectedType = selected ? type : null,
+                    ),
+                  ),
                 ),
-              )),
+              ),
             ],
           ),
         ),


### PR DESCRIPTION
## Summary
- ensure user can unselect a file type filter by tapping the selected ChoiceChip

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e9bed02288331a0ac90d1c9a0842b