### PR TITLE
Add Riverpod provider for storage permissions

### DIFF
--- a/lib/feature/storage_permission/provider/storage_permission_provider.dart
+++ b/lib/feature/storage_permission/provider/storage_permission_provider.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../services/storage_permission_service.dart';
+
+/// Provides a [StoragePermissionService] instance.
+final storagePermissionServiceProvider = Provider<StoragePermissionService>((ref) {
+  return StoragePermissionService();
+});
+
+/// Future provider that checks and requests storage permissions.
+final storagePermissionProvider = FutureProvider<bool>((ref) async {
+  final service = ref.watch(storagePermissionServiceProvider);
+  return service.checkAndRequest();
+});

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -2,9 +2,24 @@ import 'package:flutter/material.dart';
 import 'package:pdf_new/feature/files_list/file_item.dart';
 import 'package:pdf_new/feature/files_list/widget/files_list_widget.dart';
 import 'package:pdf_new/l10n/app_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../feature/storage_permission/provider/storage_permission_provider.dart';
 
-class HomeScreen extends StatelessWidget {
+class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({super.key});
+
+  @override
+  ConsumerState<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends ConsumerState<HomeScreen> {
+
+  @override
+  void initState() {
+    super.initState();
+    // Trigger the permission check using Riverpod.
+    ref.read(storagePermissionProvider.future);
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/services/storage_permission_service.dart
+++ b/lib/services/storage_permission_service.dart
@@ -1,0 +1,21 @@
+import 'package:permission_handler/permission_handler.dart';
+
+/// Service that ensures the application has storage access permissions.
+class StoragePermissionService {
+  /// Checks if storage permission is granted. If not, it requests permission
+  /// from the user. Returns `true` if permission is granted.
+  Future<bool> checkAndRequest() async {
+    var status = await Permission.storage.status;
+    if (status.isGranted) {
+      return true;
+    }
+
+    status = await Permission.storage.request();
+    if (status.isPermanentlyDenied) {
+      // Optionally open app settings so the user can grant the permission.
+      await openAppSettings();
+      return false;
+    }
+    return status.isGranted;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
     sdk: flutter
   flutter_riverpod: ^2.6.1
   shared_preferences: ^2.5.3
+  permission_handler: ^11.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- implement `storagePermissionProvider` with Riverpod
- update `HomeScreen` to check permissions via provider

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e9ed37c208331812f9bdfebc40994