### PR TITLE
Add iOS usage descriptions

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,5 +45,9 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+        <key>NSPhotoLibraryUsageDescription</key>
+        <string>This app needs access to your photo library to allow selecting images for PDFs.</string>
+        <key>NSFileProviderDomainUsageDescription</key>
+        <string>This app accesses files to create and manage PDFs.</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- request permission for photo library access
- describe why app reads files

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685ea3f5c9f483318c84bbf1050417bb